### PR TITLE
esp: color and better units

### DIFF
--- a/Menus/Main.cs
+++ b/Menus/Main.cs
@@ -50,26 +50,18 @@ namespace UmbraMenu.Menus
                 if (Loader.updateAvailable)
                 {
                     Button text1 = new Button(new TextButton(this, 2, "<color=yellow>Buttons will be availble in game.</color>"));
-                    Button text2 = new Button(new TextButton(this, 3, "<color=#11ccee>Created By Neonix#1337 and Snow#8008.\n Feel Free to Message me on discord.</color>"));
-                    Button text3 = new Button(new TextButton(this, 4, "<color=#11ccee>Download the latest version on my github.\nAcher0ns/Umbra-Mod-Menu</color>"));
                     AddButtons(new List<Button>
                     {
                         text1,
-                        text2,
-                        text3
                     });
                 }
 
                 if (Loader.upToDate || Loader.devBuild)
                 {
                     Button text1 = new Button(new TextButton(this, 2, "<color=yellow>Buttons will be availble in game.</color>"));
-                    Button text2 = new Button(new TextButton(this, 3, "<color=#11ccee>Created By Neonix#1337 and Snow#8008.\n Feel Free to Message me on discord.</color>"));
-                    Button text3 = new Button(new TextButton(this, 4, "<color=#11ccee>with bug Reports or suggestions.</color>"));
                     AddButtons(new List<Button>
                     {
                         text1,
-                        text2,
-                        text3
                     });
                 }
             }

--- a/Menus/Render.cs
+++ b/Menus/Render.cs
@@ -3,12 +3,15 @@ using UnityEngine;
 using RoR2;
 using System.Collections.Generic;
 using System.Linq;
+using UmbraMenu.monsoon;
 
 namespace UmbraMenu.Menus
 {
     public class Render : Menu
     {
         private static readonly IMenu render = new NormalMenu(6, new Rect(10, 795, 20, 20), "RENDER MENU");
+
+        private static Camera camera;
 
         public static List<PurchaseInteraction> purchaseInteractions = new List<PurchaseInteraction>();
         public static List<BarrelInteraction> barrelInteractions = new List<BarrelInteraction>();
@@ -116,22 +119,19 @@ namespace UmbraMenu.Menus
             scrappers = MonoBehaviour.FindObjectsOfType<ScrapperController>().ToList();
         }
 
-        public static void Interactables()
-        {
+        public static void DrawTeleporter() {
+            camera = Camera.main;
+
             if (TeleporterInteraction.instance)
             {
                 var teleporterInteraction = TeleporterInteraction.instance;
-                float distanceToObject = Vector3.Distance(Camera.main.transform.position, teleporterInteraction.transform.position);
-                Vector3 Position = Camera.main.WorldToScreenPoint(teleporterInteraction.transform.position);
+                float distanceToObject = Vector3.Distance(camera.transform.position, teleporterInteraction.transform.position);
+                Vector3 Position = camera.WorldToScreenPoint(teleporterInteraction.transform.position);
                 var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
                 if (BoundingVector.z > 0.01)
                 {
-                    Styles.RenderTeleporterStyle.normal.textColor =
-                        teleporterInteraction.isIdle ? Color.magenta :
-                        teleporterInteraction.isIdleToCharging || teleporterInteraction.isCharging ? Color.yellow :
-                        teleporterInteraction.isCharged ? Color.green : Color.yellow;
                     int distance = (int)distanceToObject;
-                    String friendlyName = "Teleporter";
+                    string friendlyName = "Teleporter";
                     string status = "" + (
                         teleporterInteraction.isIdle ? "Idle" :
                         teleporterInteraction.isCharging ? "Charging" :
@@ -141,88 +141,138 @@ namespace UmbraMenu.Menus
                         teleporterInteraction.isInFinalSequence ? "Final-Sequence" :
                         "???");
                     string boxText = $"{friendlyName}\n{status}\n{distance}m";
-                    GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Styles.RenderTeleporterStyle);
+                    monsoon.Renderer.DrawString(new Vector2(BoundingVector.x, (float)Screen.height - BoundingVector.y),
+                        boxText, Styles.TeleporterStyle);
                 }
             }
+        }
 
-            for (int i = 0; i < barrelInteractions.Count; i++)
+        public static void DrawInteractables()
+        {
+            foreach (PurchaseInteraction purchaseInter in purchaseInteractions)
             {
-                BarrelInteraction barrel = barrelInteractions[i];
-
-                if (!barrel.Networkopened)
-                {
-                    string friendlyName = "Barrel";
-                    Vector3 Position = Camera.main.WorldToScreenPoint(barrel.transform.position);
-                    var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
-                    if (BoundingVector.z > 0.01)
-                    {
-                        float distance = (int)Vector3.Distance(Camera.main.transform.position, barrel.transform.position);
-                        string boxText = $"{friendlyName}\n{distance}m";
-                        GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Styles.RenderInteractablesStyle);
-                    }
-                }
-            }
-
-            for (int i = 0; i < secretButtons.Count; i++)
-            {
-                PressurePlateController secretButton = secretButtons[i];
-                if (secretButton)
-                {
-                    string friendlyName = "Secret Button";
-                    Vector3 Position = Camera.main.WorldToScreenPoint(secretButton.transform.position);
-                    var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
-                    if (BoundingVector.z > 0.01)
-                    {
-                        float distance = (int)Vector3.Distance(Camera.main.transform.position, secretButton.transform.position);
-                        string boxText = $"{friendlyName}\n{distance}m";
-                        GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Styles.RenderSecretsStyle);
-                    }
-                }
-            }
-
-            for (int i = 0; i < scrappers.Count; i++)
-            {
-                ScrapperController scrapper = scrappers[i];
-                if (scrapper)
-                {
-                    string friendlyName = "Scrapper";
-                    Vector3 Position = Camera.main.WorldToScreenPoint(scrapper.transform.position);
-                    var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
-                    if (BoundingVector.z > 0.01)
-                    {
-                        float distance = (int)Vector3.Distance(Camera.main.transform.position, scrapper.transform.position);
-                        string boxText = $"{friendlyName}\n{distance}m";
-                        GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Styles.RenderInteractablesStyle);
-                    }
-                }
-            }
-
-            for (int i = 0; i < purchaseInteractions.Count; i++)
-            {
-                PurchaseInteraction purchaseInteraction = purchaseInteractions[i];
-
-                if (purchaseInteraction.available)
+                if (purchaseInter.available)
                 {
                     string dropName = null;
-                    var chest = purchaseInteraction?.gameObject.GetComponent<ChestBehavior>();
+                    var chest = purchaseInter?.gameObject.GetComponent<ChestBehavior>();
                     if (chest)
-                    {
                         dropName = Util.GenerateColoredString(Language.GetString(chest.dropPickup.GetPickupNameToken()), chest.dropPickup.GetPickupColor());
-                    }
-                    float distanceToObject = Vector3.Distance(Camera.main.transform.position, purchaseInteraction.transform.position);
-                    Vector3 Position = Camera.main.WorldToScreenPoint(purchaseInteraction.transform.position);
-                    var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
+
+                    float distanceToObject = Vector3.Distance(camera.transform.position, purchaseInter.transform.position);
+                    Vector3 Position = camera.WorldToScreenPoint(purchaseInter.transform.position);
+                    Vector3 BoundingVector = new Vector3(Position.x, Position.y, Position.z);
+
                     if (BoundingVector.z > 0.01)
                     {
                         int distance = (int)distanceToObject;
-                        String friendlyName = purchaseInteraction.GetDisplayName();
-                        int cost = purchaseInteraction.cost;
-                        string boxText = dropName != null ? $"{friendlyName}\n${cost}\n{distance}m\n{dropName}" : $"{friendlyName}\n${cost}\n{distance}m";
-                        GUI.Label(new Rect(BoundingVector.x - 50f, (float)Screen.height - BoundingVector.y, 100f, 50f), boxText, Styles.RenderInteractablesStyle);
+                        string friendlyName = purchaseInter.GetDisplayName();
+                        int cost = purchaseInter.cost;
+
+                        string boxText;
+                        if (friendlyName.Contains("Mountain") || friendlyName.Contains("Combat") || friendlyName.Contains("Printer"))
+                            boxText = $"{friendlyName}\n{distance}m";
+                        else
+                            boxText = dropName != null ?
+                                $"{friendlyName}\n{BuyingUnit(friendlyName, cost)}\n{distance}m\n{dropName}" : $"{friendlyName}\n{BuyingUnit(friendlyName, cost)}\n{distance}m";
+
+                        monsoon.Renderer.DrawString(new Vector2(BoundingVector.x, (float)Screen.height - BoundingVector.y),
+                            boxText, ChooseStyle(friendlyName));
                     }
                 }
-
             }
+        }
+
+        public static void DrawBarrels()
+        {
+            foreach (BarrelInteraction barrel in barrelInteractions)
+            {
+                if (!barrel.Networkopened)
+                {
+                    string friendlyName = "Barrel";
+                    Vector3 Position = camera.WorldToScreenPoint(barrel.transform.position);
+                    var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
+                    if (BoundingVector.z > 0.01)
+                    {
+                        float distance = (int)Vector3.Distance(camera.transform.position, barrel.transform.position);
+                        string boxText = $"{friendlyName}\n{distance}m";
+                        monsoon.Renderer.DrawString(new Vector2(BoundingVector.x, (float)Screen.height - BoundingVector.y),
+                            boxText, ChooseStyle(friendlyName));
+                    }
+                }
+            }
+        }
+
+        public static void DrawPressurePlates()
+        {
+            foreach (PressurePlateController pressurePlate in secretButtons)
+            {
+                if (pressurePlate)
+                {
+                    string friendlyName = "Secret Button";
+                    Vector3 Position = camera.WorldToScreenPoint(pressurePlate.transform.position);
+                    var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
+                    if (BoundingVector.z > 0.01)
+                    {
+                        float distance = (int)Vector3.Distance(camera.transform.position, pressurePlate.transform.position);
+                        string boxText = $"{friendlyName}\n{distance}m";
+                        monsoon.Renderer.DrawString(new Vector2(BoundingVector.x, (float)Screen.height - BoundingVector.y),
+                            boxText, ChooseStyle(friendlyName));
+                    }
+                }
+            }
+        }
+
+        public static void DrawScrappers()
+        {
+            foreach (ScrapperController scrapper in scrappers)
+            {
+                if (scrapper)
+                {
+                    string friendlyName = "Scrapper";
+                    Vector3 Position = camera.WorldToScreenPoint(scrapper.transform.position);
+                    var BoundingVector = new Vector3(Position.x, Position.y, Position.z);
+                    if (BoundingVector.z > 0.01)
+                    {
+                        float distance = (int)Vector3.Distance(camera.transform.position, scrapper.transform.position);
+                        string boxText = $"{friendlyName}\n{distance}m";
+                        monsoon.Renderer.DrawString(new Vector2(BoundingVector.x, (float)Screen.height - BoundingVector.y),
+                            boxText, ChooseStyle(friendlyName));
+                    }
+                }
+            }
+        }
+
+        private static string BuyingUnit(string name, int cost)
+        {
+            if (name.Contains("Newt") || name.Contains("Lunar") || name.Contains("Order") || name.Contains("Slab"))
+                return cost + "LC";
+            else if (name.Contains("Void") || name.Contains("Blood"))
+                return cost + "%HP";
+            return "$" + cost;
+        }
+        private static GUIStyle ChooseStyle(string name)
+        {
+            if (name.Contains("Newt"))
+                return Styles.NewtStyle;
+            else if (name.Contains("Chest") || name.Contains("Multishop") || name.Contains("Printer"))
+                return Styles.ChestStyle;
+            else if (name.Contains("Equipment"))
+                return Styles.EquipmentStyle;
+            else if (name.Contains("Lunar"))
+                return Styles.LunarStyle;
+            else if (name.Contains("Void"))
+                return Styles.VoidStyle;
+            else if (name.Contains("Gold") || name.Contains("Chance"))
+                return Styles.ChanceStyle;
+            else if (name.Contains("Blood"))
+                return Styles.BloodStyle;
+            else if (name.Contains("Combat") || name.Contains("Order"))
+                return Styles.CombatStyle;
+            else if (name.Contains("Mountain"))
+                return Styles.MountainStyle;
+            else if (name.Contains("Woods"))
+                return Styles.WoodsStyle;
+            return Styles.DefaultStyle;
         }
 
         public static void Mobs()
@@ -232,9 +282,9 @@ namespace UmbraMenu.Menus
                 var mob = HurtBox.FindEntityObject(hurtBoxes[i]);
                 if (mob)
                 {
-                    Vector3 MobPosition = Camera.main.WorldToScreenPoint(mob.transform.position);
+                    Vector3 MobPosition = camera.WorldToScreenPoint(mob.transform.position);
                     var MobBoundingVector = new Vector3(MobPosition.x, MobPosition.y, MobPosition.z);
-                    float distanceToMob = Vector3.Distance(Camera.main.transform.position, mob.transform.position);
+                    float distanceToMob = Vector3.Distance(camera.transform.position, mob.transform.position);
                     if (MobBoundingVector.z > 0.01)
                     {
                         float width = 100f * (distanceToMob / 100);

--- a/Renderer.cs
+++ b/Renderer.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+
+namespace UmbraMenu.monsoon
+{
+    public class Renderer
+    {
+        public static GUIStyle StringStyle { get; set; } = new GUIStyle(GUI.skin.label);
+
+        public static Color Color
+        {
+            get { return GUI.color; }
+            set { GUI.color = value; }
+        }
+
+        public static void DrawLine(Vector2 from, Vector2 to, Color color)
+        {
+            Color = color;
+            DrawLine(from, to);
+        }
+        public static void DrawLine(Vector2 from, Vector2 to)
+        {
+            var angle = Vector2.SignedAngle(from, to);
+            GUIUtility.RotateAroundPivot(angle, from);
+            DrawBox(from, Vector2.right * (from - to).magnitude, false);
+            GUIUtility.RotateAroundPivot(-angle, from);
+        }
+
+        public static void DrawBox(Vector2 position, Vector2 size, Color color, bool centered = true)
+        {
+            Color = color;
+            DrawBox(position, size, centered);
+        }
+        public static void DrawBox(Vector2 position, Vector2 size, bool centered = true)
+        {
+            var upperLeft = centered ? position - size / 2f : position;
+            GUI.DrawTexture(new Rect(upperLeft, size), Texture2D.whiteTexture, ScaleMode.StretchToFill);
+        }
+
+        public static void DrawString(Vector2 position, string label, GUIStyle style, bool centered = true)
+        {
+            var content = new GUIContent(label);
+            var size = StringStyle.CalcSize(content);
+            var upperLeft = centered ? position - size / 2f : position;
+            GUI.Label(new Rect(upperLeft, size), content, style);
+        }
+    }
+}

--- a/Styles.cs
+++ b/Styles.cs
@@ -4,6 +4,7 @@ namespace UmbraMenu
 {
     public static class Styles
     {
+        private static GUIStyle defaultStyle, chestStyle, newtStyle, equipmentStyle, lunarStyle, voidStyle, chanceStyle, bloodStyle, combatStyle, mountainStyle, woodsStyle, teleporterStyle;
         private static GUIStyle mainBgStyle, onStyle, offStyle, labelStyle, titleStyle, btnStyle, itemBtnStyle, cornerStyle, highlightBtnStyle, activeModsStyle, renderTeleporterStyle, renderMobsStyle, renderInteractablesStyle, renderSecretsStyle, watermarkStyle, statsStyle, selectedChestStyle;
 
         public static GUIStyle CreateGUIStyle(Texture2D normalBackground, Texture2D activeBackground, Color color, int fontSize, FontStyle font, TextAnchor textAlignmnet, bool wrapWords = false)
@@ -253,6 +254,149 @@ namespace UmbraMenu
 
                 }
                 return renderSecretsStyle;
+            }
+        }
+
+        public static GUIStyle DefaultStyle
+        {
+            get
+            {
+                if (defaultStyle == null)
+                {
+                    defaultStyle = CreateGUIStyle(null, null, new Color32(180, 200, 220, 255), 12, FontStyle.Normal, TextAnchor.MiddleCenter);
+                }
+                return defaultStyle;
+            }
+        }
+
+        public static GUIStyle ChestStyle
+        {
+            get
+            {
+                if (chestStyle == null)
+                {
+                    chestStyle = CreateGUIStyle(null, null, new Color32(40, 110, 255, 255), 12, FontStyle.Normal, TextAnchor.MiddleCenter);
+                }
+                return chestStyle;
+            }
+        }
+
+        public static GUIStyle NewtStyle
+        {
+            get
+            {
+                if (newtStyle == null)
+                {
+                    newtStyle = CreateGUIStyle(null, null, new Color32(70, 130, 220, 255), 12, FontStyle.BoldAndItalic, TextAnchor.MiddleCenter);
+                }
+                return newtStyle;
+            }
+        }
+
+        public static GUIStyle EquipmentStyle
+        {
+            get
+            {
+                if (equipmentStyle == null)
+                {
+                    equipmentStyle = CreateGUIStyle(null, null, new Color32(200, 80, 0, 255), 12, FontStyle.Normal, TextAnchor.MiddleCenter);
+                }
+                return equipmentStyle;
+            }
+        }
+
+        public static GUIStyle LunarStyle
+        {
+            get
+            {
+                if (lunarStyle == null)
+                {
+                    lunarStyle = CreateGUIStyle(null, null, new Color32(120, 175, 225, 255), 12, FontStyle.Italic, TextAnchor.MiddleCenter);
+                }
+                return lunarStyle;
+            }
+        }
+
+        public static GUIStyle VoidStyle
+        {
+            get
+            {
+                if (voidStyle == null)
+                {
+                    voidStyle = CreateGUIStyle(null, null, new Color32(250, 80, 160, 255), 12, FontStyle.Italic, TextAnchor.MiddleCenter);
+                }
+                return voidStyle;
+            }
+        }
+
+        public static GUIStyle ChanceStyle
+        {
+            get
+            {
+                if (chanceStyle == null)
+                {
+                    chanceStyle = CreateGUIStyle(null, null, new Color32(255, 255, 90, 255), 12, FontStyle.Bold, TextAnchor.MiddleCenter);
+                }
+                return chanceStyle;
+            }
+        }
+
+        public static GUIStyle BloodStyle
+        {
+            get
+            {
+                if (bloodStyle == null)
+                {
+                    bloodStyle = CreateGUIStyle(null, null, new Color32(230, 110, 100, 255), 12, FontStyle.Bold, TextAnchor.MiddleCenter);
+                }
+                return bloodStyle;
+            }
+        }
+
+        public static GUIStyle CombatStyle
+        {
+            get
+            {
+                if (combatStyle == null)
+                {
+                    combatStyle = CreateGUIStyle(null, null, new Color32(230, 165, 240, 255), 12, FontStyle.Bold, TextAnchor.MiddleCenter);
+                }
+                return combatStyle;
+            }
+        }
+
+        public static GUIStyle MountainStyle
+        {
+            get
+            {
+                if (mountainStyle == null)
+                {
+                    mountainStyle = CreateGUIStyle(null, null, new Color32(125, 230, 255, 255), 12, FontStyle.Bold, TextAnchor.MiddleCenter);
+                }
+                return mountainStyle;
+            }
+        }
+
+        public static GUIStyle WoodsStyle
+        {
+            get
+            {
+                if (woodsStyle == null)
+                {
+                    woodsStyle = CreateGUIStyle(null, null, new Color32(170, 225, 100, 255), 12, FontStyle.Bold, TextAnchor.MiddleCenter);
+                }
+                return woodsStyle;
+            }
+        }
+        public static GUIStyle TeleporterStyle
+        {
+            get
+            {
+                if (teleporterStyle == null)
+                {
+                    teleporterStyle = CreateGUIStyle(null, null, new Color32(125, 40, 70, 255), 12, FontStyle.Bold, TextAnchor.MiddleCenter);
+                }
+                return teleporterStyle;
             }
         }
         #endregion

--- a/UmbraMenu.cs
+++ b/UmbraMenu.cs
@@ -416,7 +416,11 @@ namespace UmbraMenu
             {
                 if (Menus.Render.renderInteractables)
                 {
-                    Menus.Render.Interactables();
+                    Menus.Render.DrawTeleporter();
+                    Menus.Render.DrawInteractables();
+                    Menus.Render.DrawBarrels();
+                    Menus.Render.DrawPressurePlates();
+                    Menus.Render.DrawScrappers();
                     Menus.Render.renderInteractables = true;
                 }
                 else

--- a/UmbraMenu.csproj
+++ b/UmbraMenu.csproj
@@ -94,6 +94,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <Compile Include="Reflections.cs" />
+    <Compile Include="Renderer.cs" />
     <Compile Include="Styles.cs" />
     <Compile Include="ButtonTypes\Text.cs" />
     <Compile Include="Textures.cs" />
@@ -116,13 +117,13 @@
       <HintPath>.\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>D:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="com.unity.multiplayer-hlapi.Runtime">
-      <HintPath>D:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\com.unity.multiplayer-hlapi.Runtime.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\com.unity.multiplayer-hlapi.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="HGCSharpUtils">
-      <HintPath>D:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\HGCSharpUtils.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\HGCSharpUtils.dll</HintPath>
     </Reference>
     <Reference Include="netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -133,31 +134,31 @@
       <HintPath>.\Octokit.dll</HintPath>
     </Reference>
     <Reference Include="Rewired_Core">
-      <HintPath>D:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\Rewired_Core.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\Rewired_Core.dll</HintPath>
     </Reference>
     <Reference Include="RoR2">
-      <HintPath>D:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\RoR2.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\RoR2.dll</HintPath>
     </Reference>
     <Reference Include="System">
       <HintPath>D:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\System.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>D:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>D:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>D:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>D:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextCoreModule">
-      <HintPath>D:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.TextCoreModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.TextCoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
-      <HintPath>D:\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Utility.cs
+++ b/Utility.cs
@@ -502,10 +502,6 @@ namespace UmbraMenu
                 outputFile.WriteLine(@"#        \::/____/                \::/    /                \::/____/                \:|   |                  \::/    /                        \::/    /                \::/    /                \::/    /                \::/____/        #");
                 outputFile.WriteLine(@"#         ~~                       \/____/                  ~~                       \|___|                   \/____/                          \/____/                  \/____/                  \/____/                  ~~              #");
                 outputFile.WriteLine(@"###########################################################################################################################################################################################################################################");
-                outputFile.WriteLine(@"# This is the settings file for the Risk Of Rain 2 Umbra Mod Menu.");
-                outputFile.WriteLine(@"# Created by https://www.github.com/Acher0ns");
-                outputFile.WriteLine(@"# If you need any help, add me on discord! Neonix#1337");
-                outputFile.WriteLine(@"###########################################################################################################################################################################################################################################");
                 outputFile.WriteLine($"Width: {UmbraMenu.Width}: # Menu Width Size (Any Number)");
                 outputFile.WriteLine($"Allow Navigation: {UmbraMenu.AllowNavigation}: # Enable or Disable Keyboard Navigation Feature (true/false)");
                 outputFile.WriteLine($"God Version: {UmbraMenu.GodVersion}: # Godmode Version (0-4)");
@@ -565,10 +561,6 @@ namespace UmbraMenu
                 outputFile.WriteLine(@"#       \::::/    /               /:::/    /              \::::/    /              \::|   |                  /:::/    /                       /:::/    /              \:::\____\                /:::/    /              \::::/    /       #");
                 outputFile.WriteLine(@"#        \::/____/                \::/    /                \::/____/                \:|   |                  \::/    /                        \::/    /                \::/    /                \::/    /                \::/____/        #");
                 outputFile.WriteLine(@"#         ~~                       \/____/                  ~~                       \|___|                   \/____/                          \/____/                  \/____/                  \/____/                  ~~              #");
-                outputFile.WriteLine(@"###########################################################################################################################################################################################################################################");
-                outputFile.WriteLine(@"# This is the settings file for the Risk Of Rain 2 Umbra Mod Menu.");
-                outputFile.WriteLine(@"# Created by https://www.github.com/Acher0ns");
-                outputFile.WriteLine(@"# If you need any help, add me on discord! Neonix#1337");
                 outputFile.WriteLine(@"###########################################################################################################################################################################################################################################");
                 outputFile.WriteLine($"Width: {350}: # Menu Width Size (Any Number)");
                 outputFile.WriteLine($"Allow Navigation: {true}: # Enable or Disable the Keyboard Navigation feature (True/False)");


### PR DESCRIPTION
really dirty code that can be changed A LOT just to make the esp more pleasant to look at.
just wanted to showcase a simple way to do it.

- separated each type of interactables so we can eventually create new buttons in the menu to only turn on specific ones.
- slapped a different renderer in there which i'm more used to work with (centered coordinates, yours got me triggered lol).
- each interactable category is now colored differently with different units too.

i removed on my master branch some stuff that mentionned umbra where i just wanted to have the useful infos, in the future i will create an other branch to keep that separated. for now i guess you can inspire yourself from that or just "cherry pick" the code you want (not actual git cherry pick cause only one commit).
maybe put the csproj file in the gitignore too?

was currently looking at more esp changes + optimisation (cache variables like the camera, coroutines for less calls...) so lemme know if that could be useful
